### PR TITLE
Set minimumReleaseAge to 7 days in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,5 +7,9 @@
   "major": {
     "automerge": false
   },
+  // Supply chain mitigation: don't pick up a release until it has been public for a while,
+  // so compromised versions are usually detected and unpublished before automerge sees them.
+  // Renovate's vulnerabilityAlerts updates bypass this delay by default.
+  "minimumReleaseAge": "7 days",
   "labels": ["renovate"],
 }


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: "7 days"` to the Renovate config as a supply chain attack mitigation: new releases are not picked up until they have been public for a while, so compromised versions are usually detected and unpublished before automerge sees them.
- Note: Renovate's `vulnerabilityAlerts` updates bypass this delay by default, so security fixes still arrive promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)