### PR TITLE
Upgrade jsonschema-generator to v5.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jsonschema-generator = "4.38.0"
+jsonschema-generator = "5.0.0"
 kotlin-core = "2.4.10"
 ktlint = "1.8.0"
 

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/Constants.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/Constants.kt
@@ -1,6 +1,6 @@
 package dev.hsbrysk.jsonschema
 
 const val KOTLIN_VERSION = "2.0.20"
-const val JACKSON_VERSION = "2.18.2"
+const val JACKSON_VERSION = "3.2.1"
 const val JAKARTA_VALIDATION_VERSION = "3.1.1"
 const val SWAGGER2_VERSION = "2.2.29"

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/JacksonFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/JacksonFunctionalTest.kt
@@ -41,7 +41,7 @@ class JacksonFunctionalTest {
                 id("dev.hsbrysk.jsonschema-generator")
             }
             dependencies {
-                implementation("com.fasterxml.jackson.core:jackson-databind:$JACKSON_VERSION")
+                implementation("tools.jackson.core:jackson-databind:$JACKSON_VERSION")
             }
             jsonschemaGenerator {
                 schemaVersion = SchemaVersion.DRAFT_2020_12
@@ -190,7 +190,7 @@ class JacksonFunctionalTest {
                 id("dev.hsbrysk.jsonschema-generator")
             }
             dependencies {
-                implementation("com.fasterxml.jackson.core:jackson-databind:$JACKSON_VERSION")
+                implementation("tools.jackson.core:jackson-databind:$JACKSON_VERSION")
             }
             jsonschemaGenerator {
                 schemaVersion = SchemaVersion.DRAFT_2020_12

--- a/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/task/GenerateJsonSchemaTask.kt
+++ b/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/task/GenerateJsonSchemaTask.kt
@@ -5,8 +5,8 @@ import com.github.victools.jsonschema.generator.OptionPreset
 import com.github.victools.jsonschema.generator.SchemaGenerator
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
 import com.github.victools.jsonschema.generator.SchemaVersion
-import com.github.victools.jsonschema.module.jackson.JacksonModule
 import com.github.victools.jsonschema.module.jackson.JacksonOption
+import com.github.victools.jsonschema.module.jackson.JacksonSchemaModule
 import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationModule
 import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationOption
 import com.github.victools.jsonschema.module.swagger2.Swagger2Module
@@ -118,7 +118,7 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
         )
             .apply {
                 if (jacksonEnabled.get()) {
-                    with(JacksonModule(*jacksonOptions.get().toTypedArray()))
+                    with(JacksonSchemaModule(*jacksonOptions.get().toTypedArray()))
                 }
                 if (jakartaValidationEnabled.get()) {
                     with(JakartaValidationModule(*jakartaValidationOptions.get().toTypedArray()))


### PR DESCRIPTION
## Summary

Upgrades `com.github.victools:jsonschema-generator` (and its jackson / jakarta-validation / swagger-2 modules) from **4.38.0** to **5.0.0**.

Breaking changes in v5.0.0:
- Requires Java 17+ (no impact — this project already uses toolchain 17)
- Requires Jackson 3.x (`tools.jackson.*`)

## Changes

- `gradle/libs.versions.toml`: Bump `jsonschema-generator` from `4.38.0` to `5.0.0`
- `GenerateJsonSchemaTask`: Replace `JacksonModule` with `JacksonSchemaModule`. In v5 the old class was deprecated (`@Deprecated(forRemoval = true)`) to avoid a name clash with Jackson 3's own `tools.jackson.databind.JacksonModule`, and since this project builds with `allWarningsAsErrors = true`, keeping it would fail compilation
- functionalTest: Update the databind dependency injected into test projects to the Jackson 3 coordinates `tools.jackson.core:jackson-databind:3.2.1`

Jackson 3 keeps annotations in the `com.fasterxml.jackson.annotation` package, so the sample code in test fixtures and the expected JSON outputs required no changes.

## Test plan

- [x] `./gradlew check` (unit tests + functionalTest) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)