### PR TITLE
Fix main build by migrating schemaProperty code to Jackson 3

### DIFF
--- a/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/task/GenerateJsonSchemaTask.kt
+++ b/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/task/GenerateJsonSchemaTask.kt
@@ -1,7 +1,5 @@
 package dev.hsbrysk.jsonschema.task
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.victools.jsonschema.generator.Option
 import com.github.victools.jsonschema.generator.OptionPreset
 import com.github.victools.jsonschema.generator.SchemaGenerator
@@ -25,6 +23,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ObjectNode
 import java.io.File
 import java.net.URLClassLoader
 import java.nio.file.FileSystems
@@ -134,7 +134,7 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
         }
         if (schemaPropertyRequired.get()) {
             val required = target.withArray("/required")
-            if (required.none { it.asText() == SCHEMA_PROPERTY_NAME }) {
+            if (required.none { it.asString("") == SCHEMA_PROPERTY_NAME }) {
                 required.add(SCHEMA_PROPERTY_NAME)
             }
         }
@@ -148,7 +148,7 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
     private fun resolveLocalRef(schema: ObjectNode): ObjectNode {
         var current = schema
         repeat(MAX_REF_RESOLUTION) {
-            val ref = current.path(REF_KEYWORD).asText("")
+            val ref = current.path(REF_KEYWORD).asString("")
             if (!ref.startsWith("#/")) {
                 return current
             }
@@ -158,7 +158,7 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
             }
             if (countLocalRefs(schema, ref) > 1) {
                 current.remove(REF_KEYWORD)
-                current.setAll<ObjectNode>(resolved.deepCopy())
+                current.setAll(resolved.deepCopy())
                 return current
             }
             current = resolved
@@ -170,7 +170,7 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
         node: JsonNode,
         ref: String,
     ): Int {
-        var count = if (node.path(REF_KEYWORD).asText("") == ref) 1 else 0
+        var count = if (node.path(REF_KEYWORD).asString("") == ref) 1 else 0
         node.forEach { child ->
             count += countLocalRefs(child, ref)
         }


### PR DESCRIPTION
## Summary

Fixes the CI failure on `main` introduced by the combination of #346 and #348.

The two PRs were developed in parallel and each passed CI independently, but they semantically conflict:

- #346 added the `schemaProperty` injection logic to `GenerateJsonSchemaTask` using Jackson 2 (`com.fasterxml.jackson.databind`)
- #348 upgraded `jsonschema-generator` to v5.0.0, which requires Jackson 3 (`tools.jackson.*`)

After both merged, `compileKotlin` on `main` failed with `Unresolved reference 'databind'` etc. (see [run 30262063677](https://github.com/be-hase/jsonschema-generator-tools/actions/runs/30262063677)).

## Changes

All in `GenerateJsonSchemaTask.kt`:

- Replace `com.fasterxml.jackson.databind.{JsonNode, node.ObjectNode}` imports with the Jackson 3 packages `tools.jackson.databind.{JsonNode, node.ObjectNode}`
- Replace deprecated `asText()` / `asText(default)` with `asString(default)` — Jackson 3 deprecates `asText`, which fails the build due to `allWarningsAsErrors = true`
- `setAll<ObjectNode>(...)` → `setAll(...)` — Jackson 3's `setAll(ObjectNode)` is non-generic, and `ObjectNode.deepCopy()` now has a covariant return type so no type argument is needed

## Test plan

- [x] `./gradlew publishToMavenLocal` then `./gradlew check detektMain detektTest detektFunctionalTest` (same steps as CI) passes locally
- [x] `functionalTest` re-run with `--rerun-tasks` to make sure the schemaProperty functional tests actually executed against the fixed plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)