### PR TITLE
Support configuration cache and declare task inputs/outputs

### DIFF
--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/BasicFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/BasicFunctionalTest.kt
@@ -99,6 +99,23 @@ class BasicFunctionalTest {
             .build()
         assertThat(secondResult.output).contains("Reusing configuration cache.")
         assertThat(secondResult.task(":generateJsonSchema")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+
+        // Changing an input must invalidate the up-to-date state and regenerate the schema.
+        projectDir.resolve(Path("src", "main", "java", "com", "example", "Person.java").toFile()).writeText(
+            // language=java
+            """
+            package com.example;
+            public record Person(String name, int age, String gender, String email) {}
+            """.trimIndent(),
+        )
+        val thirdResult = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments("generateJsonSchema", "--configuration-cache")
+            .build()
+        assertThat(thirdResult.task(":generateJsonSchema")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
+            .contains(""""email"""")
     }
 
     @Test

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/BasicFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/BasicFunctionalTest.kt
@@ -1,8 +1,10 @@
 package dev.hsbrysk.jsonschema
 
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.isEqualTo
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -63,7 +65,7 @@ class BasicFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
@@ -87,6 +89,16 @@ class BasicFunctionalTest {
                 }
                 """.trimIndent(),
             )
+
+        // Run again to verify that the stored configuration cache entry can be reused
+        // and that the declared output makes the task up-to-date.
+        val secondResult = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments("generateJsonSchema", "--configuration-cache")
+            .build()
+        assertThat(secondResult.output).contains("Reusing configuration cache.")
+        assertThat(secondResult.task(":generateJsonSchema")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
     }
 
     @Test
@@ -122,7 +134,7 @@ class BasicFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/JacksonFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/JacksonFunctionalTest.kt
@@ -123,7 +123,7 @@ class JacksonFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Pojo.json").toFile()).readText())
@@ -252,7 +252,7 @@ class JacksonFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Pojo.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/JakartaValidationFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/JakartaValidationFunctionalTest.kt
@@ -76,7 +76,7 @@ class JakartaValidationFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
@@ -151,7 +151,7 @@ class JakartaValidationFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/KotlinModuleFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/KotlinModuleFunctionalTest.kt
@@ -73,7 +73,7 @@ class KotlinModuleFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/MultiProjectFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/MultiProjectFunctionalTest.kt
@@ -88,7 +88,7 @@ class MultiProjectFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
         assertThat(
             projectDir.resolve(Path("three", "build", "json-schemas", "Person.json").toFile()).readText(),
@@ -183,7 +183,7 @@ class MultiProjectFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
         assertThat(
             projectDir.resolve(Path("three", "build", "json-schemas", "Person.json").toFile()).readText(),

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/OptionPresetFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/OptionPresetFunctionalTest.kt
@@ -56,7 +56,7 @@ class OptionPresetFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/OptionsFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/OptionsFunctionalTest.kt
@@ -85,7 +85,7 @@ class OptionsFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/SchemaPropertyDefinitionForMainSchemaFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/SchemaPropertyDefinitionForMainSchemaFunctionalTest.kt
@@ -40,7 +40,7 @@ class SchemaPropertyDefinitionForMainSchemaFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
@@ -85,7 +85,7 @@ class SchemaPropertyDefinitionForMainSchemaFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
@@ -130,7 +130,7 @@ class SchemaPropertyDefinitionForMainSchemaFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
@@ -176,7 +176,7 @@ class SchemaPropertyDefinitionForMainSchemaFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
@@ -223,7 +223,7 @@ class SchemaPropertyDefinitionForMainSchemaFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         // The `$schema` property must only be allowed/required at the root; the shared definition
@@ -278,7 +278,7 @@ class SchemaPropertyDefinitionForMainSchemaFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         // The `$schema` property must only be allowed/required at the root; the shared definition

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/SchemaPropertyFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/SchemaPropertyFunctionalTest.kt
@@ -57,7 +57,7 @@ class SchemaPropertyFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
@@ -115,7 +115,7 @@ class SchemaPropertyFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/SchemaVersionFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/SchemaVersionFunctionalTest.kt
@@ -54,7 +54,7 @@ class SchemaVersionFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/ServiceLoaderFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/ServiceLoaderFunctionalTest.kt
@@ -109,7 +109,7 @@ class ServiceLoaderFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
@@ -170,7 +170,7 @@ class ServiceLoaderFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/Swagger2FunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/Swagger2FunctionalTest.kt
@@ -98,7 +98,7 @@ class Swagger2FunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/TypeMappingFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/TypeMappingFunctionalTest.kt
@@ -59,7 +59,7 @@ class TypeMappingFunctionalTest {
         GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments("generateJsonSchema")
+            .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Options.json").toFile()).readText())

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/UploadJsonSchemaToS3FunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/UploadJsonSchemaToS3FunctionalTest.kt
@@ -1,7 +1,9 @@
 package dev.hsbrysk.jsonschema
 
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isNull
 import com.sun.net.httpserver.HttpServer
 import org.gradle.testkit.runner.GradleRunner
@@ -129,7 +131,7 @@ class UploadJsonSchemaToS3FunctionalTest {
         val result = GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments(UPLOAD_TASK_NAME)
+            .withArguments(UPLOAD_TASK_NAME, "--configuration-cache")
             .build()
 
         // Running the upload task alone must trigger compilation and schema generation first
@@ -144,6 +146,17 @@ class UploadJsonSchemaToS3FunctionalTest {
             .isEqualTo(projectDir.resolve(Path("build", "json-schemas", "Address.json").toFile()).readText())
         assertThat(puts[1].body)
             .isEqualTo(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
+
+        // Run again to verify that the stored configuration cache entry can be reused for the upload
+        // task, whose properties include non-trivial AWS SDK types (Region, checksum settings).
+        val secondResult = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments(UPLOAD_TASK_NAME, "--configuration-cache")
+            .build()
+        assertThat(secondResult.output).contains("Reusing configuration cache.")
+        assertThat(secondResult.task(":$UPLOAD_TASK_NAME")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(recordedRequests.count { it.method == "PUT" }).isEqualTo(4)
     }
 
     @Test
@@ -184,7 +197,7 @@ class UploadJsonSchemaToS3FunctionalTest {
         val result = GradleRunner.create()
             .withPluginClasspath()
             .withProjectDir(projectDir)
-            .withArguments(UPLOAD_TASK_NAME)
+            .withArguments(UPLOAD_TASK_NAME, "--configuration-cache")
             .build()
 
         assertThat(result.task(":$UPLOAD_TASK_NAME")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
@@ -192,6 +205,57 @@ class UploadJsonSchemaToS3FunctionalTest {
         val puts = recordedRequests.filter { it.method == "PUT" && it.path.endsWith("Person.json") }
         assertThat(puts.map { it.path }).isEqualTo(listOf("/test-bucket/schemas/v1/Person.json"))
         assertThat(puts[0].acl).isEqualTo("public-read")
+    }
+
+    @Test
+    fun `upload with custom output directory`() {
+        buildFile.writeText(
+            // language=kotlin
+            """
+            import com.github.victools.jsonschema.generator.SchemaVersion
+            import dev.hsbrysk.jsonschema.task.GenerateJsonSchemaTask
+            import software.amazon.awssdk.core.checksums.RequestChecksumCalculation
+            import software.amazon.awssdk.regions.Region
+            plugins {
+                java
+                id("dev.hsbrysk.jsonschema-generator")
+            }
+            jsonschemaGenerator {
+                schemaVersion = SchemaVersion.DRAFT_2020_12
+                schemas {
+                    create("Person") {
+                        target = "com.example.Person"
+                    }
+                }
+                s3 {
+                    accessKeyId = "dummy-access-key"
+                    secretAccessKey = "dummy-secret-key"
+                    region = Region.US_EAST_1
+                    endpoint = "http://127.0.0.1:${server.address.port}"
+                    bucket = "test-bucket"
+                    requestChecksumCalculation = RequestChecksumCalculation.WHEN_REQUIRED
+                }
+            }
+            tasks.named<GenerateJsonSchemaTask>("generateJsonSchema") {
+                outputDirectory = layout.buildDirectory.dir("custom-schemas")
+            }
+            """.trimIndent(),
+        )
+
+        val result = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments(UPLOAD_TASK_NAME, "--configuration-cache")
+            .build()
+
+        assertThat(result.task(":$UPLOAD_TASK_NAME")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        // The custom output directory must be used for generation and flow through to the upload task
+        val customOut = projectDir.resolve(Path("build", "custom-schemas", "Person.json").toFile())
+        assertThat(projectDir.resolve(Path("build", "json-schemas").toFile()).exists()).isFalse()
+        val puts = recordedRequests.filter { it.method == "PUT" && it.path.endsWith("Person.json") }
+        assertThat(puts.map { it.path }).isEqualTo(listOf("/test-bucket/Person.json"))
+        assertThat(puts[0].body).isEqualTo(customOut.readText())
     }
 
     companion object {

--- a/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/JsonSchemaGeneratorPlugin.kt
+++ b/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/JsonSchemaGeneratorPlugin.kt
@@ -5,6 +5,9 @@ import dev.hsbrysk.jsonschema.task.GenerateJsonSchemaTask
 import dev.hsbrysk.jsonschema.task.UploadJsonSchemaToS3Task
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.SourceSet
 
 class JsonSchemaGeneratorPlugin : Plugin<Project> {
     private lateinit var extension: JsonSchemaGeneratorExtension
@@ -32,7 +35,7 @@ class JsonSchemaGeneratorPlugin : Plugin<Project> {
             task.withOptions.set(optionsExtension.with)
             task.withoutOptions.set(optionsExtension.without)
             task.jacksonEnabled.set(modulesExtension.jacksonEnabled)
-            task.jacksonOptions.convention(modulesExtension.jacksonOptions)
+            task.jacksonOptions.set(modulesExtension.jacksonOptions)
             task.jakartaValidationEnabled.set(modulesExtension.jakartaValidationEnabled)
             task.jakartaValidationOptions.set(modulesExtension.jakartaValidationOptions)
             task.swagger2Enabled.set(modulesExtension.swagger2Enabled)
@@ -41,8 +44,20 @@ class JsonSchemaGeneratorPlugin : Plugin<Project> {
             task.typeMappings.set(extension.typeMappings)
             task.schemas.set(project.provider { extension.schemas.associate { it.name to it.target.get() } })
             task.customConfigs.set(extension.customConfigs)
+            task.pluginClasspath.from(project.configurations.named(CONFIGURATION_JSONSCHEMA_GENERATOR))
+            task.outputDirectory.convention(project.layout.buildDirectory.dir(OUTPUT_DIRECTORY_NAME))
+        }
 
-            task.dependsOn("classes")
+        // The main source set's classpaths carry their own task dependencies (e.g. `classes`),
+        // so no explicit dependsOn is needed here.
+        project.plugins.withType(JavaPlugin::class.java) {
+            generateJsonSchemaTask.configure { task ->
+                val mainSourceSet = project.extensions.getByType(JavaPluginExtension::class.java)
+                    .sourceSets
+                    .getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                task.compileClasspath.from(mainSourceSet.compileClasspath)
+                task.runtimeClasspath.from(mainSourceSet.runtimeClasspath)
+            }
         }
 
         project.tasks.register(
@@ -59,7 +74,12 @@ class JsonSchemaGeneratorPlugin : Plugin<Project> {
             task.requestChecksumCalculation.set(s3Extension.requestChecksumCalculation)
             task.responseChecksumValidation.set(s3Extension.responseChecksumValidation)
 
-            task.dependsOn(generateJsonSchemaTask)
+            // Wiring the generate task's output as an input also carries the task dependency.
+            task.schemaFiles.from(
+                generateJsonSchemaTask.flatMap { it.outputDirectory }.map { dir ->
+                    dir.asFileTree.matching { pattern -> pattern.include("*.json") }
+                },
+            )
         }
     }
 
@@ -90,5 +110,6 @@ class JsonSchemaGeneratorPlugin : Plugin<Project> {
 
     companion object {
         internal const val CONFIGURATION_JSONSCHEMA_GENERATOR = "jsonschemaGenerator"
+        internal const val OUTPUT_DIRECTORY_NAME = "json-schemas"
     }
 }

--- a/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/task/GenerateJsonSchemaTask.kt
+++ b/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/task/GenerateJsonSchemaTask.kt
@@ -10,17 +10,19 @@ import com.github.victools.jsonschema.module.jackson.JacksonSchemaModule
 import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationModule
 import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationOption
 import com.github.victools.jsonschema.module.swagger2.Swagger2Module
-import dev.hsbrysk.jsonschema.JsonSchemaGeneratorPlugin.Companion.CONFIGURATION_JSONSCHEMA_GENERATOR
 import dev.hsbrysk.jsonschema.ModuleProvider
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
-import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import tools.jackson.databind.JsonNode
@@ -38,9 +40,15 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
     @get:Input
     abstract val schemaVersion: Property<SchemaVersion>
 
+    // OptionPreset is not Serializable, so it cannot be fingerprinted as an @Input directly;
+    // the enabled options are exposed via optionPresetOptions instead.
+    @get:Internal
+    abstract val optionPreset: Property<OptionPreset>
+
     @get:Input
     @get:Optional
-    abstract val optionPreset: Property<OptionPreset>
+    internal val optionPresetOptions: Provider<List<String>>
+        get() = optionPreset.map { preset -> Option.entries.filter(preset::isOptionEnabledByDefault).map(Option::name) }
 
     @get:Input
     @get:Optional
@@ -89,38 +97,34 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
     abstract val customConfigs: MapProperty<String, String>
 
     @get:Classpath
-    val compileClasspath: FileCollection
+    abstract val compileClasspath: ConfigurableFileCollection
 
     @get:Classpath
-    val runtimeClasspath: FileCollection
+    abstract val runtimeClasspath: ConfigurableFileCollection
 
     @get:Classpath
-    val pluginClasspath: FileCollection
+    abstract val pluginClasspath: ConfigurableFileCollection
 
-    init {
-        val javaExtension = project.extensions.getByType(JavaPluginExtension::class.java)
-        val mainSourceSet = javaExtension.sourceSets.getByName("main")
-        compileClasspath = mainSourceSet.compileClasspath
-        runtimeClasspath = mainSourceSet.runtimeClasspath
-        pluginClasspath = project.configurations.getByName(CONFIGURATION_JSONSCHEMA_GENERATOR)
-    }
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
 
     @TaskAction
     fun generateJsonSchema() {
         val classLoader = buildClassLoader(mainDependencies() + pluginClasspath)
         val generator = buildSchemaGenerator(classLoader)
 
-        project.layout.buildDirectory.get().file("json-schemas").asFile.mkdirs()
-        schemas.get().forEach { name, target ->
+        val outputDir = outputDirectory.get().asFile
+        outputDir.mkdirs()
+        schemas.get().forEach { (name, target) ->
             val clazz = classLoader.loadClass(target)
             val schema = generator.generateSchema(clazz)
             if (schemaPropertyEnabled.get()) {
                 injectSchemaProperty(schema)
             }
 
-            val outPath = project.layout.buildDirectory.get().file("json-schemas/$name.json").asFile
+            val outPath = outputDir.resolve("$name.json")
             outPath.writeText(schema.toPrettyString())
-            println("Generated JSON schema: ${outPath.absolutePath}")
+            logger.lifecycle("Generated JSON schema: ${outPath.absolutePath}")
         }
     }
 
@@ -235,10 +239,7 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
         }
     }
 
-    // We will refer to the jar built within a Gradle project as `builtJar`.
-    private val builtJarMatcher = FileSystems.getDefault().getPathMatcher("glob:**/build/libs/*.jar")
-
-    fun isBuiltJar(path: Path): Boolean = builtJarMatcher.matches(path)
+    fun isBuiltJar(path: Path): Boolean = BUILT_JAR_MATCHER.matches(path)
 
     fun findClassesAndResourcesFromBuildJar(path: Path): List<File> {
         // **/build/libs/*.jar -> **/build
@@ -272,5 +273,9 @@ abstract class GenerateJsonSchemaTask : DefaultTask() {
         private const val SCHEMA_PROPERTY_NAME = "\$schema"
         private const val REF_KEYWORD = "\$ref"
         private const val MAX_REF_RESOLUTION = 10
+
+        // We will refer to the jar built within a Gradle project as `builtJar`.
+        // Kept out of the task instance so that the configuration cache does not try to serialize it.
+        private val BUILT_JAR_MATCHER = FileSystems.getDefault().getPathMatcher("glob:**/build/libs/*.jar")
     }
 }

--- a/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/task/UploadJsonSchemaToS3Task.kt
+++ b/jsonschema-generator-gradle-plugin/src/main/kotlin/dev/hsbrysk/jsonschema/task/UploadJsonSchemaToS3Task.kt
@@ -1,9 +1,13 @@
 package dev.hsbrysk.jsonschema.task
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
@@ -53,15 +57,17 @@ abstract class UploadJsonSchemaToS3Task : DefaultTask() {
     @get:Optional
     abstract val responseChecksumValidation: Property<ResponseChecksumValidation>
 
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val schemaFiles: ConfigurableFileCollection
+
     @TaskAction
     fun uploadJsonSchemaToS3() {
         val bucket = bucket.get()
         val dir = dir.orNull?.removeSuffix("/")
 
         buildS3Client().use { s3Client ->
-            val files = project.layout.buildDirectory.dir("json-schemas").get().asFileTree
-                .matching { it.include("*.json") }
-            files.forEach { file ->
+            schemaFiles.forEach { file ->
                 s3Client.putObject(
                     PutObjectRequest.builder()
                         .bucket(bucket)


### PR DESCRIPTION
## Summary

Makes the plugin compatible with Gradle's configuration cache and properly declares task inputs/outputs so Gradle can manage dependencies and up-to-date checks.

Built on top of the test coverage added in #352, which pins down the S3 upload behavior this PR rewires.

### Configuration cache support
- Removed `Task.project` usage at execution time from `GenerateJsonSchemaTask` and `UploadJsonSchemaToS3Task` (accessing `project` in a `@TaskAction` is disallowed with the configuration cache)
- Moved the `PathMatcher` field into the companion object since it cannot be serialized into the cache
- `OptionPreset` is not `Serializable` and cannot be fingerprinted as an `@Input`; the property is now `@Internal` and the enabled option names are exposed as the actual `@Input` instead

### Declared inputs/outputs
- The schema output directory is now a proper `@OutputDirectory` (`outputDirectory`, defaulting to `build/json-schemas` as before), so it is configurable and the task is skipped as `UP-TO-DATE` when nothing changed
- `UploadJsonSchemaToS3Task` receives the generated schemas as `@InputFiles` wired from the generate task's output, replacing the manual `dependsOn` wiring
- Main source set classpaths are wired from the plugin inside `plugins.withType(JavaPlugin)`, replacing `dependsOn("classes")` (classpath inputs carry their own task dependencies) and avoiding a confusing failure when the `java` plugin is not applied
- Also aligned `jacksonOptions` wiring to `.set()` like the other properties (was `.convention()`)

### Tests
- All functional tests (including the S3 upload tests from #352) now run with `--configuration-cache`
- `BasicFunctionalTest` additionally verifies that the cache entry is reused (`Reusing configuration cache.`), that an unchanged build is `UP-TO-DATE`, and that changing a source class invalidates the up-to-date state and regenerates the schema
- `UploadJsonSchemaToS3FunctionalTest` additionally verifies that a custom `outputDirectory` is used for generation and flows through to the upload task, and that the upload task's configuration cache entry (containing AWS SDK types like `Region`) can be stored and reused

🤖 Generated with [Claude Code](https://claude.com/claude-code)