### PR TITLE
Add test coverage for error paths, Groovy DSL, and untested logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ jsonschemaGenerator {
 
     // Use this when you want to treat a specific type as a different type.
     // It is useful when you are using something like a value object.
+    // A mapping applies not only to the exact type but also to its subtypes/implementations.
+    // When multiple mappings match, the first one in the configured order wins,
+    // so put more specific types before broader ones.
     // Default: empty
     typeMappings = mapOf(
         "com.example.SecretString" to "java.lang.Integer",

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/FailureFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/FailureFunctionalTest.kt
@@ -138,6 +138,7 @@ class FailureFunctionalTest {
 
         // Schema generation itself succeeds; only the upload task fails on the missing bucket
         assertThat(result.task(":generateJsonSchema")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.task(":uploadJsonSchemaToS3")?.outcome).isEqualTo(TaskOutcome.FAILED)
         assertThat(result.output).contains("bucket")
     }
 }

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/FailureFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/FailureFunctionalTest.kt
@@ -1,0 +1,143 @@
+package dev.hsbrysk.jsonschema
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.io.path.Path
+
+/**
+ * Pins down the error messages users see for common misconfigurations.
+ */
+class FailureFunctionalTest {
+    @field:TempDir
+    lateinit var projectDir: File
+
+    private val buildFile by lazy { projectDir.resolve("build.gradle.kts") }
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle.kts") }
+
+    @BeforeEach
+    fun beforeEach() {
+        settingsFile.writeText(
+            // language=kotlin
+            """
+            dependencyResolutionManagement {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            """.trimIndent(),
+        )
+
+        projectDir.resolve(Path("src", "main", "java", "com", "example").toFile()).mkdirs()
+        projectDir.resolve(Path("src", "main", "java", "com", "example", "Person.java").toFile()).writeText(
+            // language=java
+            """
+            package com.example;
+            public record Person(String name, int age, String gender) {}
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `schema target class not found`() {
+        buildFile.writeText(
+            // language=kotlin
+            """
+            import com.github.victools.jsonschema.generator.SchemaVersion
+            plugins {
+                java
+                id("dev.hsbrysk.jsonschema-generator")
+            }
+            jsonschemaGenerator {
+                schemaVersion = SchemaVersion.DRAFT_2020_12
+                schemas {
+                    create("Missing") {
+                        target = "com.example.Missing"
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val result = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments("generateJsonSchema", "--configuration-cache")
+            .buildAndFail()
+
+        assertThat(result.task(":generateJsonSchema")?.outcome).isEqualTo(TaskOutcome.FAILED)
+        assertThat(result.output).contains("com.example.Missing")
+    }
+
+    @Test
+    fun `type mapping class not found`() {
+        buildFile.writeText(
+            // language=kotlin
+            """
+            import com.github.victools.jsonschema.generator.SchemaVersion
+            plugins {
+                java
+                id("dev.hsbrysk.jsonschema-generator")
+            }
+            jsonschemaGenerator {
+                schemaVersion = SchemaVersion.DRAFT_2020_12
+                typeMappings = mapOf(
+                    "java.time.Duration" to "com.example.DoesNotExist",
+                )
+                schemas {
+                    create("Person") {
+                        target = "com.example.Person"
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val result = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments("generateJsonSchema", "--configuration-cache")
+            .buildAndFail()
+
+        assertThat(result.task(":generateJsonSchema")?.outcome).isEqualTo(TaskOutcome.FAILED)
+        assertThat(result.output).contains("com.example.DoesNotExist")
+    }
+
+    @Test
+    fun `upload without bucket`() {
+        buildFile.writeText(
+            // language=kotlin
+            """
+            import com.github.victools.jsonschema.generator.SchemaVersion
+            plugins {
+                java
+                id("dev.hsbrysk.jsonschema-generator")
+            }
+            jsonschemaGenerator {
+                schemaVersion = SchemaVersion.DRAFT_2020_12
+                schemas {
+                    create("Person") {
+                        target = "com.example.Person"
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+
+        val result = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments("uploadJsonSchemaToS3", "--configuration-cache")
+            .buildAndFail()
+
+        // Schema generation itself succeeds; only the upload task fails on the missing bucket
+        assertThat(result.task(":generateJsonSchema")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(result.output).contains("bucket")
+    }
+}

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/GroovyDslFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/GroovyDslFunctionalTest.kt
@@ -1,0 +1,102 @@
+package dev.hsbrysk.jsonschema
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.io.path.Path
+
+/**
+ * All other functional tests use the Kotlin DSL. Groovy resolves extension properties
+ * differently, so make sure the plugin DSL also works from a `build.gradle`.
+ */
+class GroovyDslFunctionalTest {
+    @field:TempDir
+    lateinit var projectDir: File
+
+    private val buildFile by lazy { projectDir.resolve("build.gradle") }
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle") }
+
+    @BeforeEach
+    fun beforeEach() {
+        settingsFile.writeText(
+            // language=groovy
+            """
+            dependencyResolutionManagement {
+                repositories {
+                    mavenCentral()
+                }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun groovy() {
+        buildFile.writeText(
+            // language=groovy
+            """
+            import com.github.victools.jsonschema.generator.SchemaVersion
+            plugins {
+                id 'java'
+                id 'dev.hsbrysk.jsonschema-generator'
+            }
+            jsonschemaGenerator {
+                schemaVersion = SchemaVersion.DRAFT_2020_12
+                schemaProperty {
+                    enabled = true
+                }
+                schemas {
+                    Person {
+                        target = 'com.example.Person'
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+
+        projectDir.resolve(Path("src", "main", "java", "com", "example").toFile()).mkdirs()
+        projectDir.resolve(Path("src", "main", "java", "com", "example", "Person.java").toFile()).writeText(
+            // language=java
+            """
+            package com.example;
+            public record Person(String name, int age, String gender) {}
+            """.trimIndent(),
+        )
+
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments("generateJsonSchema", "--configuration-cache")
+            .build()
+
+        assertThat(projectDir.resolve(Path("build", "json-schemas", "Person.json").toFile()).readText())
+            .isEqualTo(
+                // language=json
+                """
+                {
+                  "${'$'}schema" : "https://json-schema.org/draft/2020-12/schema",
+                  "type" : "object",
+                  "properties" : {
+                    "age" : {
+                      "type" : "integer"
+                    },
+                    "gender" : {
+                      "type" : "string"
+                    },
+                    "name" : {
+                      "type" : "string"
+                    },
+                    "${'$'}schema" : {
+                      "type" : "string"
+                    }
+                  },
+                  "required" : [ "${'$'}schema" ]
+                }
+                """.trimIndent(),
+            )
+    }
+}

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/TypeMappingFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/TypeMappingFunctionalTest.kt
@@ -86,7 +86,7 @@ class TypeMappingFunctionalTest {
     }
 
     @Test
-    fun `subtype matching and precedence`() {
+    fun `supertype matching`() {
         buildFile.writeText(
             // language=kotlin
             """
@@ -98,8 +98,6 @@ class TypeMappingFunctionalTest {
             jsonschemaGenerator {
                 schemaVersion = SchemaVersion.DRAFT_2020_12
                 typeMappings = mapOf(
-                    "java.time.Duration" to "java.lang.Integer",
-                    // Duration also implements TemporalAmount, but the first matching mapping wins
                     "java.time.temporal.TemporalAmount" to "java.lang.String",
                 )
                 schemas {
@@ -128,6 +126,7 @@ class TypeMappingFunctionalTest {
             .withArguments("generateJsonSchema", "--configuration-cache")
             .build()
 
+        // Both Duration and Period implement TemporalAmount, so the mapping applies to both
         assertThat(projectDir.resolve(Path("build", "json-schemas", "Times.json").toFile()).readText())
             .isEqualTo(
                 // language=json
@@ -140,7 +139,67 @@ class TypeMappingFunctionalTest {
                       "type" : "string"
                     },
                     "timeout" : {
-                      "type" : "integer"
+                      "type" : "string"
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `configured-order precedence`() {
+        buildFile.writeText(
+            // language=kotlin
+            """
+            import com.github.victools.jsonschema.generator.SchemaVersion
+            plugins {
+                java
+                id("dev.hsbrysk.jsonschema-generator")
+            }
+            jsonschemaGenerator {
+                schemaVersion = SchemaVersion.DRAFT_2020_12
+                typeMappings = mapOf(
+                    "java.time.temporal.TemporalAmount" to "java.lang.String",
+                    "java.time.Duration" to "java.lang.Integer",
+                )
+                schemas {
+                    create("Times") {
+                        target = "com.example.Times"
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+
+        projectDir.resolve(Path("src", "main", "java", "com", "example").toFile()).mkdirs()
+        projectDir.resolve(Path("src", "main", "java", "com", "example", "Times.java").toFile()).writeText(
+            // language=java
+            """
+            package com.example;
+            import java.time.Duration;
+            public record Times(Duration timeout) {}
+            """.trimIndent(),
+        )
+
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments("generateJsonSchema", "--configuration-cache")
+            .build()
+
+        // The first configured mapping wins even when a more specific mapping exists later:
+        // Duration is matched by TemporalAmount -> String, not by Duration -> Integer.
+        assertThat(projectDir.resolve(Path("build", "json-schemas", "Times.json").toFile()).readText())
+            .isEqualTo(
+                // language=json
+                """
+                {
+                  "${'$'}schema" : "https://json-schema.org/draft/2020-12/schema",
+                  "type" : "object",
+                  "properties" : {
+                    "timeout" : {
+                      "type" : "string"
                     }
                   }
                 }

--- a/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/TypeMappingFunctionalTest.kt
+++ b/jsonschema-generator-gradle-plugin/src/functionalTest/kotlin/dev/hsbrysk/jsonschema/TypeMappingFunctionalTest.kt
@@ -84,4 +84,67 @@ class TypeMappingFunctionalTest {
                 """.trimIndent(),
             )
     }
+
+    @Test
+    fun `subtype matching and precedence`() {
+        buildFile.writeText(
+            // language=kotlin
+            """
+            import com.github.victools.jsonschema.generator.SchemaVersion
+            plugins {
+                java
+                id("dev.hsbrysk.jsonschema-generator")
+            }
+            jsonschemaGenerator {
+                schemaVersion = SchemaVersion.DRAFT_2020_12
+                typeMappings = mapOf(
+                    "java.time.Duration" to "java.lang.Integer",
+                    // Duration also implements TemporalAmount, but the first matching mapping wins
+                    "java.time.temporal.TemporalAmount" to "java.lang.String",
+                )
+                schemas {
+                    create("Times") {
+                        target = "com.example.Times"
+                    }
+                }
+            }
+            """.trimIndent(),
+        )
+
+        projectDir.resolve(Path("src", "main", "java", "com", "example").toFile()).mkdirs()
+        projectDir.resolve(Path("src", "main", "java", "com", "example", "Times.java").toFile()).writeText(
+            // language=java
+            """
+            package com.example;
+            import java.time.Duration;
+            import java.time.Period;
+            public record Times(Duration timeout, Period period) {}
+            """.trimIndent(),
+        )
+
+        GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(projectDir)
+            .withArguments("generateJsonSchema", "--configuration-cache")
+            .build()
+
+        assertThat(projectDir.resolve(Path("build", "json-schemas", "Times.json").toFile()).readText())
+            .isEqualTo(
+                // language=json
+                """
+                {
+                  "${'$'}schema" : "https://json-schema.org/draft/2020-12/schema",
+                  "type" : "object",
+                  "properties" : {
+                    "period" : {
+                      "type" : "string"
+                    },
+                    "timeout" : {
+                      "type" : "integer"
+                    }
+                  }
+                }
+                """.trimIndent(),
+            )
+    }
 }

--- a/jsonschema-module-kotlin/src/test/kotlin/dev/hsbrysk/jsonschema/module/kotlin/KotlinModuleProviderTest.kt
+++ b/jsonschema-module-kotlin/src/test/kotlin/dev/hsbrysk/jsonschema/module/kotlin/KotlinModuleProviderTest.kt
@@ -1,0 +1,40 @@
+package dev.hsbrysk.jsonschema.module.kotlin
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import org.junit.jupiter.api.Test
+
+class KotlinModuleProviderTest {
+    private val provider = KotlinModuleProvider()
+
+    @Test
+    fun `no config`() {
+        val module = provider.provide(emptyMap()) as KotlinModule
+        assertThat(module.options.toList()).isEmpty()
+    }
+
+    @Test
+    fun `single option`() {
+        val module = provider.provide(mapOf("kotlin.options" to "USE_NULLABLE")) as KotlinModule
+        assertThat(module.options.toList()).isEqualTo(listOf(KotlinOption.USE_NULLABLE))
+    }
+
+    @Test
+    fun `multiple options with whitespace`() {
+        val module = provider.provide(
+            mapOf("kotlin.options" to "USE_NULLABLE, USE_REQUIRED_VIA_DEFAULT_ARGS"),
+        ) as KotlinModule
+        assertThat(module.options.toList())
+            .isEqualTo(listOf(KotlinOption.USE_NULLABLE, KotlinOption.USE_REQUIRED_VIA_DEFAULT_ARGS))
+    }
+
+    @Test
+    fun `unknown option`() {
+        assertFailure {
+            provider.provide(mapOf("kotlin.options" to "USE_NULLABL"))
+        }.isInstanceOf(IllegalArgumentException::class)
+    }
+}

--- a/jsonschema-module-kotlin/src/test/kotlin/dev/hsbrysk/jsonschema/module/kotlin/KotlinModuleTest.kt
+++ b/jsonschema-module-kotlin/src/test/kotlin/dev/hsbrysk/jsonschema/module/kotlin/KotlinModuleTest.kt
@@ -65,6 +65,40 @@ class KotlinModuleTest {
             """.trimIndent(),
         )
     }
+
+    @Test
+    fun useRequiredViaDefaultArgsWithBodyProperty() {
+        val generator = SchemaGenerator(
+            SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .with(KotlinModule(KotlinOption.USE_REQUIRED_VIA_DEFAULT_ARGS))
+                .build(),
+        )
+        // A property declared in the class body is not a constructor parameter, so it must not be required
+        assertThat(generator.generateSchema(WithBodyProperty::class.java).toPrettyString()).isEqualTo(
+            """
+            {
+              "${'$'}schema" : "https://json-schema.org/draft/2020-12/schema",
+              "type" : "object",
+              "properties" : {
+                "age" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                },
+                "nickname" : {
+                  "type" : "string"
+                }
+              },
+              "required" : [ "age" ]
+            }
+            """.trimIndent(),
+        )
+    }
 }
 
 data class Person(val name: String = "NONAME", val age: Int, val gender: String?)
+
+data class WithBodyProperty(val name: String = "NONAME", val age: Int) {
+    val nickname: String = name
+}


### PR DESCRIPTION
## Summary

Follow-up to #352, filling the remaining test coverage gaps identified while reviewing the codebase. All happy paths were already well covered; this adds the areas that were not.

### Error paths (`FailureFunctionalTest`)

No test exercised a failure before. These pin down the errors users actually see for common misconfigurations:
- `target` pointing to a class that does not exist
- `typeMappings` referencing a class that does not exist
- Running `uploadJsonSchemaToS3` without configuring `bucket` (schema generation still succeeds; only the upload fails)

These serve as a baseline if we later want to improve the error messages.

### Groovy DSL (`GroovyDslFunctionalTest`)

All functional tests used the Kotlin DSL. Groovy resolves extension properties differently, so this adds a smoke test using a `build.gradle`, including a nested extension block (`schemaProperty { enabled = true }`) and the dynamic container syntax for `schemas`.

### Untested logic

- `TypeMappingFunctionalTest`: the implementation matches via `isAssignableFrom`, but only exact matches were tested. Now covers supertype/interface matching (`TemporalAmount` → `Period`) and first-match precedence between mappings
- `KotlinModuleProviderTest` (new): the `kotlin.options` parsing had no direct tests — covers absent key, single value, whitespace trimming, and unknown option names (currently an `IllegalArgumentException`)
- `KotlinModuleTest`: covers `USE_REQUIRED_VIA_DEFAULT_ARGS` for a property declared in the class body rather than the primary constructor (must not be required)

Note: the known crash of `KotlinModule` on Java classes / classes without a primary constructor is intentionally *not* pinned down here — that should be fixed and tested together in a separate PR.

### Docs

Also documents the typeMappings behavior established by these tests in the README: mappings apply to subtypes/implementations, and the first configured mapping wins, so more specific types should come first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)