### PR TITLE
Fix KotlinModule crash on non-Kotlin classes

### DIFF
--- a/jsonschema-module-kotlin/src/main/kotlin/dev/hsbrysk/jsonschema/module/kotlin/KotlinModule.kt
+++ b/jsonschema-module-kotlin/src/main/kotlin/dev/hsbrysk/jsonschema/module/kotlin/KotlinModule.kt
@@ -11,20 +11,19 @@ class KotlinModule(vararg val options: KotlinOption) : Module {
     override fun applyToConfigBuilder(builder: SchemaGeneratorConfigBuilder) {
         if (options.contains(KotlinOption.USE_NULLABLE)) {
             builder.forFields().withNullableCheck { field ->
-                checkNotNull(field.rawMember.kotlinProperty).returnType.isMarkedNullable
+                // Returning null leaves the decision to the default handling,
+                // so fields of non-Kotlin classes are unaffected.
+                field.rawMember.kotlinProperty?.returnType?.isMarkedNullable
             }
         }
 
         if (options.contains(KotlinOption.USE_REQUIRED_VIA_DEFAULT_ARGS)) {
             builder.forFields().withRequiredCheck { field ->
-                val primaryConstructor =
-                    checkNotNull(field.rawMember.declaringClass.kotlin.primaryConstructor)
-                val param = primaryConstructor.parameters.firstOrNull { field.name == it.name }
-                if (param == null) {
-                    false
-                } else {
-                    !param.isOptional
-                }
+                // Non-Kotlin classes and classes without a primary constructor have no
+                // default-argument information, so nothing is marked as required.
+                val primaryConstructor = field.rawMember.declaringClass.kotlin.primaryConstructor
+                val param = primaryConstructor?.parameters?.firstOrNull { field.name == it.name }
+                param != null && !param.isOptional
             }
         }
     }

--- a/jsonschema-module-kotlin/src/test/java/dev/hsbrysk/jsonschema/module/kotlin/JavaPerson.java
+++ b/jsonschema-module-kotlin/src/test/java/dev/hsbrysk/jsonschema/module/kotlin/JavaPerson.java
@@ -1,0 +1,3 @@
+package dev.hsbrysk.jsonschema.module.kotlin;
+
+public record JavaPerson(String name, int age) {}

--- a/jsonschema-module-kotlin/src/test/kotlin/dev/hsbrysk/jsonschema/module/kotlin/KotlinModuleTest.kt
+++ b/jsonschema-module-kotlin/src/test/kotlin/dev/hsbrysk/jsonschema/module/kotlin/KotlinModuleTest.kt
@@ -95,10 +95,73 @@ class KotlinModuleTest {
             """.trimIndent(),
         )
     }
+
+    @Test
+    fun javaClass() {
+        val generator = SchemaGenerator(
+            SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .with(KotlinModule(KotlinOption.USE_NULLABLE, KotlinOption.USE_REQUIRED_VIA_DEFAULT_ARGS))
+                .build(),
+        )
+        // Non-Kotlin classes must not crash; nullability and required fall back to the defaults
+        assertThat(generator.generateSchema(JavaPerson::class.java).toPrettyString()).isEqualTo(
+            """
+            {
+              "${'$'}schema" : "https://json-schema.org/draft/2020-12/schema",
+              "type" : "object",
+              "properties" : {
+                "age" : {
+                  "type" : "integer"
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun classWithoutPrimaryConstructor() {
+        val generator = SchemaGenerator(
+            SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .with(KotlinModule(KotlinOption.USE_NULLABLE, KotlinOption.USE_REQUIRED_VIA_DEFAULT_ARGS))
+                .build(),
+        )
+        // Without a primary constructor there is no default-argument information,
+        // so nothing is required; nullability still works via the property types
+        assertThat(generator.generateSchema(NoPrimaryConstructor::class.java).toPrettyString()).isEqualTo(
+            """
+            {
+              "${'$'}schema" : "https://json-schema.org/draft/2020-12/schema",
+              "type" : "object",
+              "properties" : {
+                "age" : {
+                  "type" : [ "integer", "null" ]
+                },
+                "name" : {
+                  "type" : "string"
+                }
+              }
+            }
+            """.trimIndent(),
+        )
+    }
 }
 
 data class Person(val name: String = "NONAME", val age: Int, val gender: String?)
 
 data class WithBodyProperty(val name: String = "NONAME", val age: Int) {
     val nickname: String = name
+}
+
+class NoPrimaryConstructor {
+    val name: String
+    val age: Int?
+
+    constructor(name: String, age: Int?) {
+        this.name = name
+        this.age = age
+    }
 }


### PR DESCRIPTION
## Summary

`KotlinModule` crashed with an `IllegalStateException` when the schema generation target contained non-Kotlin classes or Kotlin classes without a primary constructor. In a mixed Kotlin/Java codebase, a single Java class reachable from a schema target broke the whole generation.

### Fixes

- **`USE_NULLABLE`**: `checkNotNull(field.rawMember.kotlinProperty)` threw for fields of Java classes. It now returns `null` instead, which leaves the nullability decision to victools' default handling — fields of non-Kotlin classes are simply unaffected by the option.
- **`USE_REQUIRED_VIA_DEFAULT_ARGS`**: `checkNotNull(...primaryConstructor)` threw for Java classes and for Kotlin classes that only have secondary constructors. Such fields are now simply not marked as required, since there is no default-argument information to derive from.

### Tests

- A Java record processed with both options enabled generates a schema without crashing, falling back to default nullability/required handling
- A Kotlin class with only a secondary constructor is not marked as required, while `USE_NULLABLE` still works via its property types

This was one of the issues found in the initial code review (deferred until the test-coverage PRs #352/#353 landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)